### PR TITLE
Improve responsive layout with better tablet and mobile support

### DIFF
--- a/static/assets/css/split.css
+++ b/static/assets/css/split.css
@@ -126,6 +126,18 @@ body.page-template-page-fullsingle-split {
   overflow-x: hidden;
   max-width: 100%;
 }
+@media (max-width: 1024px) and (min-width: 768px) {
+  body.page-template-page-fullsingle-split {
+    font-size: 19px;
+    line-height: 30px;
+  }
+}
+@media (max-width: 767px) {
+  body.page-template-page-fullsingle-split {
+    font-size: 18px;
+    line-height: 28px;
+  }
+}
 body.page-template-page-fullsingle-split p {
   color: #848d96;
   word-wrap: break-word;
@@ -137,7 +149,12 @@ body.page-template-page-fullsingle-split p {
   height: 100vh;
   display: flex;
 }
-@media (max-width: 800px) {
+@media (max-width: 1024px) and (min-width: 768px) {
+  .fs-split {
+    height: 100vh;
+  }
+}
+@media (max-width: 767px) {
   .fs-split {
     height: auto;
     flex-wrap: wrap;
@@ -148,9 +165,14 @@ body.page-template-page-fullsingle-split p {
   height: 100vh;
   background-size: cover;
 }
-@media (max-width: 800px) {
+@media (max-width: 1024px) and (min-width: 768px) {
   .fs-split .split-image {
-    height: 80vh;
+    width: 45%;
+  }
+}
+@media (max-width: 767px) {
+  .fs-split .split-image {
+    height: 60vh;
     width: 100%;
   }
 }
@@ -162,7 +184,12 @@ body.page-template-page-fullsingle-split p {
   justify-content: center;
   overflow: auto;
 }
-@media (max-width: 800px) {
+@media (max-width: 1024px) and (min-width: 768px) {
+  .fs-split .split-content {
+    width: 55%;
+  }
+}
+@media (max-width: 767px) {
   .fs-split .split-content {
     width: 100%;
     height: auto;
@@ -176,19 +203,24 @@ body.page-template-page-fullsingle-split p {
   width: 100%;
   box-sizing: border-box;
 }
-@media (max-width: 1200px) {
+@media (max-width: 1200px) and (min-width: 1025px) {
   .fs-split .split-content .split-content-vertically-center {
-    padding: 60px;
+    padding: 70px;
   }
 }
-@media (max-width: 800px) {
+@media (max-width: 1024px) and (min-width: 768px) {
+  .fs-split .split-content .split-content-vertically-center {
+    padding: 50px;
+  }
+}
+@media (max-width: 767px) and (min-width: 600px) {
   .fs-split .split-content .split-content-vertically-center {
     padding: 40px;
   }
 }
-@media (max-width: 500px) {
+@media (max-width: 599px) {
   .fs-split .split-content .split-content-vertically-center {
-    padding: 20px;
+    padding: 30px 20px;
   }
 }
 
@@ -200,18 +232,25 @@ body.page-template-page-fullsingle-split p {
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
-@media (max-width: 800px) {
+@media (max-width: 1024px) and (min-width: 768px) {
   .split-intro {
-    font-size: 42px;
-    line-height: 52px;
-    letter-spacing: -1px;
+    font-size: 52px;
+    line-height: 64px;
+    letter-spacing: -1.5px;
   }
 }
-@media (max-width: 500px) {
+@media (max-width: 767px) and (min-width: 600px) {
+  .split-intro {
+    font-size: 44px;
+    line-height: 54px;
+    letter-spacing: -1.2px;
+  }
+}
+@media (max-width: 599px) {
   .split-intro {
     font-size: 32px;
     line-height: 40px;
-    letter-spacing: -0.5px;
+    letter-spacing: -0.8px;
   }
 }
 .split-intro h1 {
@@ -235,14 +274,19 @@ body.page-template-page-fullsingle-split p {
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
-@media (max-width: 1200px) {
+@media (max-width: 1200px) and (min-width: 1025px) {
+  .split-bio {
+    padding: 35px 0 15px 0;
+  }
+}
+@media (max-width: 1024px) and (min-width: 768px) {
   .split-bio {
     padding: 30px 0 10px 0;
   }
 }
-@media (max-width: 800px) {
+@media (max-width: 767px) {
   .split-bio {
-    padding: 20px 0 0 0;
+    padding: 25px 0 10px 0;
   }
 }
 .split-bio p {
@@ -366,9 +410,16 @@ body.page-template-page-fullsingle-split p {
   margin-bottom: 40px;
   vertical-align: top;
 }
-@media (max-width: 500px) {
+@media (max-width: 1024px) and (min-width: 768px) {
   .split-lists .split-list {
-    width: 90%;
+    width: 45%;
+    margin-right: 5%;
+  }
+}
+@media (max-width: 767px) {
+  .split-lists .split-list {
+    width: 100%;
+    margin-right: 0;
   }
 }
 .split-lists .split-list h3 {


### PR DESCRIPTION
- Add dedicated breakpoints for tablet landscape (768-1024px) and portrait (600-767px)
- Maintain desktop layout (50/50 split) for screens >1024px as before
- Tablet landscape gets 45/55 split for better content readability
- Adjust font sizes progressively: 64px (desktop) -> 52px (tablet landscape) -> 44px (tablet portrait) -> 32px (mobile)
- Update padding scales for each breakpoint to optimize spacing
- Improve list layouts for tablets with 2-column layout
- Reduce mobile image height from 80vh to 60vh for better content visibility

This ensures the desktop experience is preserved while providing optimized layouts for tablets and mobile devices.