### PR TITLE
Remove border-box styling to reduce excess whitespace

### DIFF
--- a/static/assets/css/split.css
+++ b/static/assets/css/split.css
@@ -63,7 +63,6 @@ table {
   text-rendering: optimizeLegibility;
   -moz-font-feature-settings: "liga" on;
   margin: 0;
-  box-sizing: border-box;
 }
 
 img.alignright {
@@ -210,21 +209,18 @@ body.page-template-page-fullsingle-split p {
   .fs-split .split-content .split-content-vertically-center {
     padding: 50px;
     width: 100%;
-    box-sizing: border-box;
   }
 }
 @media (max-width: 767px) and (min-width: 600px) {
   .fs-split .split-content .split-content-vertically-center {
     padding: 40px;
     width: 100%;
-    box-sizing: border-box;
   }
 }
 @media (max-width: 599px) {
   .fs-split .split-content .split-content-vertically-center {
     padding: 30px 20px;
     width: 100%;
-    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
Removed box-sizing: border-box from universal selector and media queries to eliminate excess whitespace issues in the layout.